### PR TITLE
orm:validate-schema should be opt-in only.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -11,7 +11,7 @@ return array(
     'diagnostics' => array(
         'DoctrineORMDiagnosticsModule' => array(
             'Database Connection' => 'doctrine.orm_diagnostics.connection',
-            'ORM Validate Schema' => 'doctrine.orm_diagnostics.schema',
+            //'ORM Validate Schema' => 'doctrine.orm_diagnostics.schema',
         ),
     ),
 );


### PR DESCRIPTION
orm:schema-tool:update behaves differently than migrations:diff, so orm:validate-schema should be opt-in only.
